### PR TITLE
Add secondary Nav Bar to Services view

### DIFF
--- a/cypress/fixtures/app_data.json
+++ b/cypress/fixtures/app_data.json
@@ -24,7 +24,39 @@
         },
         {
           "label": "services",
-          "link": "/services"
+          "link": "/services",
+          "secondary_tabs": [
+            {
+              "label": "Find a service",
+              "link": "/services",
+              "ref": "find-a-service"
+            },
+            {
+              "label": "KCSC Self Care",
+              "link": "/services",
+              "ref": "kcsc-self-care"
+            },
+            {
+              "label": "KCSC CLW",
+              "link": "/services",
+              "ref": "kcsc-clw"
+            },
+            {
+              "label": "KCSC N Ken SC",
+              "link": "/services",
+              "ref": "kcsc-n-ken-sc"
+            },
+            {
+              "label": "Link workers",
+              "link": "/services",
+              "ref": "link-workers"
+            },
+            {
+              "label": "Other VCS lg contracts",
+              "link": "/services",
+              "ref": "other-vcs-lg-contracts"
+            }
+          ]
         },
         {
           "label": "about",
@@ -69,6 +101,42 @@
           "parent": "news & info",
           "label": "information",
           "link": "/info/information"
+        },
+        {
+          "parent": "services",
+          "label": "Find a service",
+          "link": "/services",
+          "ref": "find-a-service"
+        },
+        {
+          "parent": "services",
+          "label": "KCSC Self Care",
+          "link": "/services",
+          "ref": "kcsc-self-care"
+        },
+        {
+          "parent": "services",
+          "label": "KCSC CLW",
+          "link": "/services",
+          "ref": "kcsc-clw"
+        },
+        {
+          "parent": "services",
+          "label": "KCSC N Ken SC",
+          "link": "/services",
+          "ref": "kcsc-n-ken-sc"
+        },
+        {
+          "parent": "services",
+          "label": "Link workers",
+          "link": "/services",
+          "ref": "link-workers"
+        },
+        {
+          "parent": "services",
+          "label": "Other VCS lg contracts",
+          "link": "/services",
+          "ref": "other-vcs-lg-contracts"
         }
       ]
     },

--- a/cypress/integration/desktop/visitorCanNavigateBetweenSPAViews.feature.js
+++ b/cypress/integration/desktop/visitorCanNavigateBetweenSPAViews.feature.js
@@ -139,55 +139,6 @@ describe("visitor can navigate between views", () => {
     });
   });
 
-  describe("Services View", () => {
-    beforeEach(() => {
-      cy.intercept("GET", "**/api/sections**", {
-        fixture: "services_view_section.json",
-      });
-      cy.visit("/");
-      cy.get("[data-cy=application-header]").within(() => {
-        cy.get("[data-cy=services-tab]").click();
-      });
-    });
-
-    it("is expected to show logo in the header", () => {
-      cy.get("[data-cy=header-logo]")
-        .should("have.attr", "alt")
-        .should("equal", "Community Health West London");
-    });
-
-    it("is expected to display service page ", () => {
-      cy.get("[data-cy=page-section]").should("have.length", 6);
-      cy.get("[data-cy=page-section]")
-        .first()
-        .within(() => {
-          cy.get("[data-cy=header]").should("contain.text", "Find a service");
-          cy.get("[data-cy=description]").should(
-            "contain.text",
-            "On this page, you can find all available services in your area"
-          );
-          cy.get("[data-cy=image]").should("not.exist");
-        });
-      cy.get("[data-cy=page-section]")
-        .eq(1)
-        .within(() => {
-          cy.get("[data-cy=header]").should("contain.text", "KCSC Self Care");
-          cy.get("[data-cy=description]").should(
-            "contain.text",
-            "The Voluntary & Community Sector provide health and wellbeing services in North Kensington Communities to support those affected by the Grenfell Tower fire."
-          );
-          cy.get("[data-cy=image]").should("be.visible");
-          cy.get("[data-cy=button_1]").should(
-            "contain.text",
-            "Find self-care service"
-          );
-          cy.get("[data-cy=button_1]")
-            .invoke("attr", "href")
-            .should("eq", "http://localhost:3001/search");
-        });
-    });
-  });
-
   describe("navigate back to home page", () => {
     beforeEach(() => {
       cy.visit("/services/search");

--- a/cypress/integration/desktop/visitorCanNavigateServicesView.feature.js
+++ b/cypress/integration/desktop/visitorCanNavigateServicesView.feature.js
@@ -1,0 +1,55 @@
+describe("visitor can navigate Services View", () => {
+  beforeEach(() => {
+    cy.intercept("GET", "**/api/sections**", {
+      fixture: "services_view_section.json",
+    });
+    cy.visit("/");
+    cy.get("[data-cy=application-header]").within(() => {
+      cy.get("[data-cy=services-tab]").click();
+    });
+  });
+
+  it("is expected to show logo in the header", () => {
+    cy.get("[data-cy=header-logo]")
+      .should("have.attr", "alt")
+      .should("equal", "Community Health West London");
+  });
+
+  it("is expected to display service page ", () => {
+    cy.get("[data-cy=page-section]").should("have.length", 6);
+    cy.get("[data-cy=page-section]")
+      .first()
+      .within(() => {
+        cy.get("[data-cy=header]").should("contain.text", "Find a service");
+        cy.get("[data-cy=description]").should(
+          "contain.text",
+          "On this page, you can find all available services in your area"
+        );
+        cy.get("[data-cy=image]").should("not.exist");
+      });
+    cy.get("[data-cy=page-section]")
+      .eq(1)
+      .within(() => {
+        cy.get("[data-cy=header]").should("contain.text", "KCSC Self Care");
+        cy.get("[data-cy=description]").should(
+          "contain.text",
+          "The Voluntary & Community Sector provide health and wellbeing services in North Kensington Communities to support those affected by the Grenfell Tower fire."
+        );
+        cy.get("[data-cy=image]").should("be.visible");
+        cy.get("[data-cy=button_1]").should(
+          "contain.text",
+          "Find self-care service"
+        );
+        cy.get("[data-cy=button_1]")
+          .invoke("attr", "href")
+          .should("eq", "http://localhost:3001/services/search");
+      });
+  });
+
+  it("is expected to scroll when using secondary navbar", () => {
+    cy.get("[data-cy=other-vcs-lg-contracts-sub-tab]").click();
+    cy.window()
+      .its("scrollY")
+      .should("not.equal", 0);
+  });
+});

--- a/cypress/integration/desktop/visitorCanNavigateServicesView.feature.js
+++ b/cypress/integration/desktop/visitorCanNavigateServicesView.feature.js
@@ -47,6 +47,7 @@ describe("visitor can navigate Services View", () => {
   });
 
   it("is expected to scroll when using secondary navbar", () => {
+    cy.scrollTo(0, 0)
     cy.get("[data-cy=other-vcs-lg-contracts-sub-tab]").click();
     cy.window()
       .its("scrollY")

--- a/cypress/integration/desktop/visitorCanNavigateUsingHeader.feature.js
+++ b/cypress/integration/desktop/visitorCanNavigateUsingHeader.feature.js
@@ -16,7 +16,6 @@ describe("visitor can navigate between views", () => {
   it("is expected to navigate to services page", () => {
     cy.get("[data-cy=services-tab]").click();
     cy.url().should("include", "/services");
-    cy.get("[data-cy=secondary-nav-bar]").should("not.exist");
     cy.get("[data-cy=services-tab]").should("have.class", "Mui-selected");
   });
 

--- a/cypress/integration/mobile/landscape/visitorCanNavigateBetweenSPAViews.feature.js
+++ b/cypress/integration/mobile/landscape/visitorCanNavigateBetweenSPAViews.feature.js
@@ -140,54 +140,6 @@ describe("visitor can navigate between views", () => {
     });
   });
 
-  describe("Services View", () => {
-    beforeEach(() => {
-      cy.intercept("GET", "**/api/sections**", {
-        fixture: "services_view_section.json",
-      });
-      cy.visit("/");
-      cy.get("[data-cy=burger-menu]").click();
-      cy.get("[data-cy=services-tab]").click();
-    });
-
-    it("is expected to show logo in the header", () => {
-      cy.get("[data-cy=header-logo]")
-        .should("have.attr", "alt")
-        .should("equal", "Community Health West London");
-    });
-
-    it("is expected to display service page ", () => {
-      cy.get("[data-cy=page-section]").should("have.length", 6);
-      cy.get("[data-cy=page-section]")
-        .first()
-        .within(() => {
-          cy.get("[data-cy=header]").should("contain.text", "Find a service");
-          cy.get("[data-cy=description]").should(
-            "contain.text",
-            "On this page, you can find all available services in your area"
-          );
-          cy.get("[data-cy=image]").should("not.exist");
-        });
-      cy.get("[data-cy=page-section]")
-        .eq(1)
-        .within(() => {
-          cy.get("[data-cy=header]").should("contain.text", "KCSC Self Care");
-          cy.get("[data-cy=description]").should(
-            "contain.text",
-            "The Voluntary & Community Sector provide health and wellbeing services in North Kensington Communities to support those affected by the Grenfell Tower fire."
-          );
-          cy.get("[data-cy=image]").should("be.visible");
-          cy.get("[data-cy=button_1]").should(
-            "contain.text",
-            "Find self-care service"
-          );
-          cy.get("[data-cy=button_1]")
-            .invoke("attr", "href")
-            .should("eq", "http://localhost:3001/search");
-        });
-    });
-  });
-
   describe("navigate back to home page", () => {
     beforeEach(() => {
       cy.visit("/services/search");

--- a/cypress/integration/mobile/landscape/visitorCanNavigateServicesView.feature.js
+++ b/cypress/integration/mobile/landscape/visitorCanNavigateServicesView.feature.js
@@ -1,0 +1,55 @@
+describe("visitor can navigate Services View", () => {
+  beforeEach(() => {
+    cy.intercept("GET", "**/api/sections**", {
+      fixture: "services_view_section.json",
+    });
+    cy.visit("/");
+    cy.get("[data-cy=application-header]").within(() => {
+      cy.get("[data-cy=services-tab]").click();
+    });
+  });
+
+  it("is expected to show logo in the header", () => {
+    cy.get("[data-cy=header-logo]")
+      .should("have.attr", "alt")
+      .should("equal", "Community Health West London");
+  });
+
+  it("is expected to display service page ", () => {
+    cy.get("[data-cy=page-section]").should("have.length", 6);
+    cy.get("[data-cy=page-section]")
+      .first()
+      .within(() => {
+        cy.get("[data-cy=header]").should("contain.text", "Find a service");
+        cy.get("[data-cy=description]").should(
+          "contain.text",
+          "On this page, you can find all available services in your area"
+        );
+        cy.get("[data-cy=image]").should("not.exist");
+      });
+    cy.get("[data-cy=page-section]")
+      .eq(1)
+      .within(() => {
+        cy.get("[data-cy=header]").should("contain.text", "KCSC Self Care");
+        cy.get("[data-cy=description]").should(
+          "contain.text",
+          "The Voluntary & Community Sector provide health and wellbeing services in North Kensington Communities to support those affected by the Grenfell Tower fire."
+        );
+        cy.get("[data-cy=image]").should("be.visible");
+        cy.get("[data-cy=button_1]").should(
+          "contain.text",
+          "Find self-care service"
+        );
+        cy.get("[data-cy=button_1]")
+          .invoke("attr", "href")
+          .should("eq", "http://localhost:3001/services/search");
+      });
+  });
+
+  it("is expected to scroll when using secondary navbar", () => {
+    cy.get("[data-cy=other-vcs-lg-contracts-sub-tab]").click();
+    cy.window()
+      .its("scrollY")
+      .should("not.equal", 0);
+  });
+});

--- a/cypress/integration/mobile/landscape/visitorCanNavigateServicesView.feature.js
+++ b/cypress/integration/mobile/landscape/visitorCanNavigateServicesView.feature.js
@@ -1,12 +1,13 @@
 describe("visitor can navigate Services View", () => {
   beforeEach(() => {
+    cy.viewport("iphone-x", "landscape");
     cy.intercept("GET", "**/api/sections**", {
       fixture: "services_view_section.json",
     });
     cy.visit("/");
-    cy.get("[data-cy=application-header]").within(() => {
-      cy.get("[data-cy=services-tab]").click();
-    });
+    cy.get("[data-cy=burger-menu]").click();
+    cy.get("[data-cy=services-tab]").click();
+    cy.get("[data-cy=kcsc-clw-tab]").click();
   });
 
   it("is expected to show logo in the header", () => {
@@ -47,7 +48,10 @@ describe("visitor can navigate Services View", () => {
   });
 
   it("is expected to scroll when using secondary navbar", () => {
-    cy.get("[data-cy=other-vcs-lg-contracts-sub-tab]").click();
+    cy.scrollTo(0, 0)
+    cy.get("[data-cy=burger-menu]").click();
+    cy.get("[data-cy=services-tab]").click();
+    cy.get("[data-cy=other-vcs-lg-contracts-tab]").click();
     cy.window()
       .its("scrollY")
       .should("not.equal", 0);

--- a/cypress/integration/mobile/visitorCanNavigateBetweenSPAViews.feature.js
+++ b/cypress/integration/mobile/visitorCanNavigateBetweenSPAViews.feature.js
@@ -143,54 +143,6 @@ describe("visitor can navigate between views", () => {
     });
   });
 
-  describe("Services View", () => {
-    beforeEach(() => {
-      cy.intercept("GET", "**/api/sections**", {
-        fixture: "services_view_section.json",
-      });
-      cy.visit("/");
-      cy.get("[data-cy=burger-menu]").click();
-      cy.get("[data-cy=services-tab]").click();
-    });
-
-    it("is expected to show logo in the header", () => {
-      cy.get("[data-cy=header-logo]")
-        .should("have.attr", "alt")
-        .should("equal", "Community Health West London");
-    });
-
-    it("is expected to display service page ", () => {
-      cy.get("[data-cy=page-section]").should("have.length", 6);
-      cy.get("[data-cy=page-section]")
-        .first()
-        .within(() => {
-          cy.get("[data-cy=header]").should("contain.text", "Find a service");
-          cy.get("[data-cy=description]").should(
-            "contain.text",
-            "On this page, you can find all available services in your area"
-          );
-          cy.get("[data-cy=image]").should("not.exist");
-        });
-      cy.get("[data-cy=page-section]")
-        .eq(1)
-        .within(() => {
-          cy.get("[data-cy=header]").should("contain.text", "KCSC Self Care");
-          cy.get("[data-cy=description]").should(
-            "contain.text",
-            "The Voluntary & Community Sector provide health and wellbeing services in North Kensington Communities to support those affected by the Grenfell Tower fire."
-          );
-          cy.get("[data-cy=image]").should("be.visible");
-          cy.get("[data-cy=button_1]").should(
-            "contain.text",
-            "Find self-care service"
-          );
-          cy.get("[data-cy=button_1]")
-            .invoke("attr", "href")
-            .should("eq", "http://localhost:3001/search");
-        });
-    });
-  });
-
   describe("navigate back to home page", () => {
     beforeEach(() => {
       cy.visit("/services/search");

--- a/cypress/integration/mobile/visitorCanNavigateServicesView.feature.js
+++ b/cypress/integration/mobile/visitorCanNavigateServicesView.feature.js
@@ -1,0 +1,55 @@
+describe("visitor can navigate Services View", () => {
+  beforeEach(() => {
+    cy.intercept("GET", "**/api/sections**", {
+      fixture: "services_view_section.json",
+    });
+    cy.visit("/");
+    cy.get("[data-cy=application-header]").within(() => {
+      cy.get("[data-cy=services-tab]").click();
+    });
+  });
+
+  it("is expected to show logo in the header", () => {
+    cy.get("[data-cy=header-logo]")
+      .should("have.attr", "alt")
+      .should("equal", "Community Health West London");
+  });
+
+  it("is expected to display service page ", () => {
+    cy.get("[data-cy=page-section]").should("have.length", 6);
+    cy.get("[data-cy=page-section]")
+      .first()
+      .within(() => {
+        cy.get("[data-cy=header]").should("contain.text", "Find a service");
+        cy.get("[data-cy=description]").should(
+          "contain.text",
+          "On this page, you can find all available services in your area"
+        );
+        cy.get("[data-cy=image]").should("not.exist");
+      });
+    cy.get("[data-cy=page-section]")
+      .eq(1)
+      .within(() => {
+        cy.get("[data-cy=header]").should("contain.text", "KCSC Self Care");
+        cy.get("[data-cy=description]").should(
+          "contain.text",
+          "The Voluntary & Community Sector provide health and wellbeing services in North Kensington Communities to support those affected by the Grenfell Tower fire."
+        );
+        cy.get("[data-cy=image]").should("be.visible");
+        cy.get("[data-cy=button_1]").should(
+          "contain.text",
+          "Find self-care service"
+        );
+        cy.get("[data-cy=button_1]")
+          .invoke("attr", "href")
+          .should("eq", "http://localhost:3001/services/search");
+      });
+  });
+
+  it("is expected to scroll when using secondary navbar", () => {
+    cy.get("[data-cy=other-vcs-lg-contracts-sub-tab]").click();
+    cy.window()
+      .its("scrollY")
+      .should("not.equal", 0);
+  });
+});

--- a/cypress/integration/mobile/visitorCanNavigateServicesView.feature.js
+++ b/cypress/integration/mobile/visitorCanNavigateServicesView.feature.js
@@ -1,12 +1,13 @@
 describe("visitor can navigate Services View", () => {
   beforeEach(() => {
+    cy.viewport("iphone-x");
     cy.intercept("GET", "**/api/sections**", {
       fixture: "services_view_section.json",
     });
     cy.visit("/");
-    cy.get("[data-cy=application-header]").within(() => {
-      cy.get("[data-cy=services-tab]").click();
-    });
+    cy.get("[data-cy=burger-menu]").click();
+    cy.get("[data-cy=services-tab]").click();
+    cy.get("[data-cy=kcsc-clw-tab]").click();
   });
 
   it("is expected to show logo in the header", () => {
@@ -47,7 +48,10 @@ describe("visitor can navigate Services View", () => {
   });
 
   it("is expected to scroll when using secondary navbar", () => {
-    cy.get("[data-cy=other-vcs-lg-contracts-sub-tab]").click();
+    cy.scrollTo(0, 0)
+    cy.get("[data-cy=burger-menu]").click();
+    cy.get("[data-cy=services-tab]").click();
+    cy.get("[data-cy=other-vcs-lg-contracts-tab]").click();
     cy.window()
       .its("scrollY")
       .should("not.equal", 0);

--- a/cypress/integration/mobile/visitorCanNavigateUsingHeader.feature.js
+++ b/cypress/integration/mobile/visitorCanNavigateUsingHeader.feature.js
@@ -20,8 +20,8 @@ describe("visitor can navigate between views", () => {
 
     it("is expected to navigate to services page", () => {
       cy.get("[data-cy=services-tab]").click();
-      cy.url().should("include", "/services");
-      cy.get("[data-cy=secondary-nav-bar]").should("not.exist");
+      cy.get("[data-cy=kcsc-clw-tab]").click();
+      cy.url().should("include", "/services");      
     });
 
     it("is expected to navigate to about organization page", () => {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-helmet-async": "^1.0.9",
     "react-redux": "^7.2.4",
     "react-router-dom": "^5.2.0",
+    "react-router-hash-link": "^2.4.3",
     "react-scripts": "4.0.3",
     "redux": "^4.1.0",
     "redux-thunk": "^2.3.0",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -2,11 +2,13 @@ import React from "react";
 import { Container, Box } from "@material-ui/core";
 import Navbar from "./Navbar/Navbar";
 import ApplicationFooter from "./ApplicationFooter";
-import MessageModal from './MessageModal'
+import MessageModal from "./MessageModal";
+import ScrollToTop from "./ScrollToTop";
 
 const App = ({ component }) => {
   return (
     <>
+      <ScrollToTop />
       <MessageModal />
       <Navbar />
       <Container maxWidth="xl">

--- a/src/components/Navbar/ApplicationHeader.jsx
+++ b/src/components/Navbar/ApplicationHeader.jsx
@@ -12,6 +12,7 @@ import {
 
 import { ReactComponent as Logo } from "../../assets/LogoCHWLHorisontal.svg";
 import AppData from "../../modules/AppData";
+import { HashLink } from "react-router-hash-link";
 
 const ApplicationHeader = () => {
   const trigger = useScrollTrigger();
@@ -33,6 +34,7 @@ const ApplicationHeader = () => {
 
   const handleChangeMain = (event, newValue) => {
     setActiveMainTab(newValue);
+    setActiveSecondaryTab(0);
   };
 
   const handleChangeSecondary = (event, newValue) => {
@@ -62,8 +64,9 @@ const ApplicationHeader = () => {
         style={styles.secondaryTabText}
         data-cy={`${toKebabCase(tab.label)}-sub-tab`}
         label={tab.label}
-        component={Link}
-        to={tab.link}
+        component={tab.ref ? HashLink : Link}
+        smooth={tab.ref ? true : undefined}
+        to={tab.ref ? `${tab.link}#${tab.ref}` : tab.link}
       />
     ));
 
@@ -88,20 +91,20 @@ const ApplicationHeader = () => {
               {mainTabs}
             </Tabs>
           </Toolbar>
+          {secondaryTabs.length !== 0 && (
+            <Toolbar data-cy="secondary-nav-bar" style={styles.secondaryNavBar}>
+              <Tabs
+                style={styles.navTabs}
+                value={activeSecondaryTab}
+                onChange={handleChangeSecondary}
+                centered
+              >
+                {secondaryTabs}
+              </Tabs>
+            </Toolbar>
+          )}
         </AppBar>
       </Slide>
-      {secondaryTabs.length !== 0 && (
-        <Toolbar data-cy="secondary-nav-bar" style={styles.secondaryNavBar}>
-          <Tabs
-            style={styles.navTabs}
-            value={activeSecondaryTab}
-            onChange={handleChangeSecondary}
-            centered
-          >
-            {secondaryTabs}
-          </Tabs>
-        </Toolbar>
-      )}
     </>
   );
 };
@@ -124,11 +127,9 @@ const styles = {
   },
   secondaryNavBar: {
     backgroundColor: "#eee",
-    position: "absolute",
     borderTop: "1px solid #ccc",
     borderBottom: "1px solid #ccc",
     left: "0",
-    top: "64px",
     width: "100%",
   },
   secondaryTabText: {

--- a/src/components/Navbar/MobileApplicationHeader.jsx
+++ b/src/components/Navbar/MobileApplicationHeader.jsx
@@ -14,9 +14,9 @@ import {
   Divider,
 } from "@material-ui/core";
 import MenuIcon from "@material-ui/icons/Menu";
-
 import CHWLLogo from "../../assets/LogoCHWLMobile.png";
 import AppData from "../../modules/AppData";
+import { HashLink } from "react-router-hash-link";
 
 const MobileApplicationHeader = () => {
   const trigger = useScrollTrigger();
@@ -24,7 +24,10 @@ const MobileApplicationHeader = () => {
   const landingPage = useRouteMatch("/home");
   const { appData, appDataFetched } = useSelector((state) => state);
   const { main_tabs } = appData.navigation;
-  const [aboutOpen, setAboutOpen] = useState(false);
+  const [tabOpen, setTabOpen] = useState({
+    about: false,
+    services: false,
+  });
 
   useEffect(() => {
     const fetchApplicationData = async () => {
@@ -43,12 +46,15 @@ const MobileApplicationHeader = () => {
   };
   const handleDrawerClose = () => {
     setDrawerOpen(false);
+    setTabOpen({
+      about: false,
+      services: false,
+    });
   };
 
   const toggleOpen = (tabLabel) => {
-    if (tabLabel === "about") {
-      setAboutOpen(!aboutOpen);
-    }
+    let open = tabOpen[tabLabel];
+    setTabOpen({ ...tabOpen, [tabLabel]: !open });
   };
 
   const mainTabs = main_tabs.map((tab, index) => {
@@ -71,8 +77,13 @@ const MobileApplicationHeader = () => {
           style={styles.secondaryTabText}
           data-cy={`${toKebabCase(secondaryTab.label)}-tab`}
           label={secondaryTab.label}
-          component={Link}
-          to={secondaryTab.link}
+          component={secondaryTab.ref ? HashLink : Link}
+          smooth={secondaryTab.ref ? true : undefined}
+          to={
+            secondaryTab.ref
+              ? `${secondaryTab.link}#${secondaryTab.ref}`
+              : secondaryTab.link
+          }
           onClick={() => handleDrawerClose()}
         />
       ));
@@ -89,7 +100,7 @@ const MobileApplicationHeader = () => {
           />
           <Collapse
             style={{ width: "100%" }}
-            in={aboutOpen}
+            in={tabOpen[tab.label]}
             timeout="auto"
             unmountOnExit
           >

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    if (!pathname.includes("#")) {
+      window.scrollTo(0, 0);
+    }    
+  }, [pathname]);
+
+  return null;
+}
+
+export default ScrollToTop

--- a/src/data/fixtures/app_data.json
+++ b/src/data/fixtures/app_data.json
@@ -69,6 +69,36 @@
           "parent": "news & info",
           "label": "information",
           "link": "/info/information"
+        },
+        {
+          "parent": "services",
+          "label": "KCSC Self Care",
+          "link": "/services",
+          "ref": "kcsc-self-care"
+        },
+        {
+          "parent": "services",
+          "label": "KCSC CLW",
+          "link": "/services",
+          "ref": "kcsc-clw"
+        },
+        {
+          "parent": "services",
+          "label": "KCSC N Ken SC",
+          "link": "/services",
+          "ref": "kcsc-n-ken-sc"
+        },
+        {
+          "parent": "services",
+          "label": "Link workers",
+          "link": "/services",
+          "ref": "link-workers"
+        },
+        {
+          "parent": "services",
+          "label": "Other VCS lg contracts",
+          "link": "/services",
+          "ref": "other-vcs-lg-contracts"
         }
       ]
     },

--- a/src/data/fixtures/app_data.json
+++ b/src/data/fixtures/app_data.json
@@ -27,6 +27,11 @@
           "link": "/services",
           "secondary_tabs": [
             {
+              "label": "Find a service",
+              "link": "/services",
+              "ref": "find-a-service"
+            },
+            {
               "label": "KCSC Self Care",
               "link": "/services",
               "ref": "kcsc-self-care"
@@ -96,6 +101,12 @@
           "parent": "news & info",
           "label": "information",
           "link": "/info/information"
+        },
+        {
+          "parent": "services",
+          "label": "Find a service",
+          "link": "/services",
+          "ref": "find-a-service"
         },
         {
           "parent": "services",

--- a/src/data/fixtures/app_data.json
+++ b/src/data/fixtures/app_data.json
@@ -24,7 +24,34 @@
         },
         {
           "label": "services",
-          "link": "/services"
+          "link": "/services",
+          "secondary_tabs": [
+            {
+              "label": "KCSC Self Care",
+              "link": "/services",
+              "ref": "kcsc-self-care"
+            },
+            {
+              "label": "KCSC CLW",
+              "link": "/services",
+              "ref": "kcsc-clw"
+            },
+            {
+              "label": "KCSC N Ken SC",
+              "link": "/services",
+              "ref": "kcsc-n-ken-sc"
+            },
+            {
+              "label": "Link workers",
+              "link": "/services",
+              "ref": "link-workers"
+            },
+            {
+              "label": "Other VCS lg contracts",
+              "link": "/services",
+              "ref": "other-vcs-lg-contracts"
+            }
+          ]
         },
         {
           "label": "about",

--- a/src/views/ContactView.jsx
+++ b/src/views/ContactView.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Helmet } from "react-helmet-async";
 import { useSelector } from "react-redux";
 import { useMediaQuery, useTheme, Grid } from "@material-ui/core";

--- a/src/views/ContactView.jsx
+++ b/src/views/ContactView.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { Helmet } from "react-helmet-async";
 import { useSelector } from "react-redux";
 import { useMediaQuery, useTheme, Grid } from "@material-ui/core";

--- a/src/views/ServicesView.jsx
+++ b/src/views/ServicesView.jsx
@@ -8,6 +8,9 @@ import SectionSelector from "../components/Section/SectionSelector";
 const ServicesView = () => {
   const [sections, setSections] = useState([]);
 
+  const toKebabCase = (string) =>
+  string.replace(/\s+/g, "-").replace("&", "and").toLowerCase();
+
   useEffect(() => {
     const fetchPageData = async () => {
       //let response = await Sections.read("services")
@@ -20,7 +23,7 @@ const ServicesView = () => {
   const sectionList = sections.map(
     (section) => {
       return (
-        <Grid item key={section.id}>
+        <Grid item key={section.id} id={toKebabCase(section.header)}>
           <SectionSelector
             id={section.id}
             section={section}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9832,6 +9832,13 @@ react-router-dom@^5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
+react-router-hash-link@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/react-router-hash-link/-/react-router-hash-link-2.4.3.tgz#570824d53d6c35ce94d73a46c8e98673a127bf08"
+  integrity sha512-NU7GWc265m92xh/aYD79Vr1W+zAIXDWp3L2YZOYP4rCqPnJ6LI6vh3+rKgkidtYijozHclaEQTAHaAaMWPVI4A==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-router@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.0.tgz#424e75641ca8747fbf76e5ecca69781aa37ea293"


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/178909357
### User Story:
```
As a User
To quickly navigate the page
I want to have secondary navigation menu on top
```
### Changes Proposed
- adds secondary navBar to services view
- click on navBar tab scrolls corresponding service into view
- refactors navBar to show / hide on scroll trigger
- refactors Mobile Nav Bar to expand / collaps corresponding secondary tabs
- adds scroll to 0 on route change
### New Dependencies Added
- react-router-hash-link (to scroll to element in DOM by #id)
### Video

https://user-images.githubusercontent.com/79849155/127858078-b696f218-4121-47ce-be3e-e6453abd6673.mp4

https://user-images.githubusercontent.com/79849155/127858245-529d03e0-a559-4da7-b6d7-653a34d61892.mp4

