### PR TITLE
info header / body length

### DIFF
--- a/src/components/Information/InformationCard.jsx
+++ b/src/components/Information/InformationCard.jsx
@@ -37,7 +37,7 @@ export default InformationCard;
 
 const styles = {
   fullHeight: {
-    height: "100%",
+    height: "250px",
   },
   cardContent: {
     padding: "30px 20px",

--- a/src/components/Information/InformationCard.jsx
+++ b/src/components/Information/InformationCard.jsx
@@ -11,9 +11,9 @@ import ArrowForwardIosIcon from "@material-ui/icons/ArrowForwardIos";
 const InformationCard = ({ item }) => {
   const { header, description, link } = item;
   return (
-    <Card elevation={2} style={styles.fullHeight}>
-      <CardActionArea href={link} target='_blank' style={styles.fullHeight} data-cy="action-area">
-        <Grid container direction="row" style={styles.fullHeight}>
+    <Card elevation={2} >
+      <CardActionArea href={link} target='_blank' style={styles.cardActionArea} data-cy="action-area">
+        <Grid container direction="row" >
           <Grid item sm={10} xs={11}>
             <CardContent style={styles.cardContent}>
               <Typography gutterBottom variant="h5" component="h2" data-cy="header">
@@ -24,8 +24,8 @@ const InformationCard = ({ item }) => {
               </Typography>
             </CardContent>
           </Grid>
-          <Grid item sm={2} xs={1}>
-            <ArrowForwardIosIcon color="secondary" style={styles.fullHeight} />
+          <Grid item container sm={2} xs={1} alignContent='center' style={styles.arrow}>
+            <ArrowForwardIosIcon color="secondary" />
           </Grid>
         </Grid>
       </CardActionArea>
@@ -36,10 +36,18 @@ const InformationCard = ({ item }) => {
 export default InformationCard;
 
 const styles = {
-  fullHeight: {
-    height: "250px",
+  card: {
+    height: "270px",
+    width: '100%'
+  },
+  cardActionArea: {
+    height: '280px'
   },
   cardContent: {
     padding: "30px 20px",
+    height: '100%'
   },
+  arrow: {
+    height: '270px'
+  }
 };

--- a/src/components/Information/InformationItem.jsx
+++ b/src/components/Information/InformationItem.jsx
@@ -55,7 +55,7 @@ const styles = {
     minHeight: "148px",
   },
   fullHeight: {
-    height: "100%",
+    height: "150px",
   },
   cardContent: {
     padding: "30px 20px",

--- a/src/components/Information/InformationItem.jsx
+++ b/src/components/Information/InformationItem.jsx
@@ -52,7 +52,7 @@ export default InformationItem;
 
 const styles = {
   card: {
-    minHeight: "148px",
+    minHeight: "150px",
   },
   fullHeight: {
     height: "150px",

--- a/src/views/InformationView.jsx
+++ b/src/views/InformationView.jsx
@@ -68,7 +68,7 @@ const InformationView = () => {
 
   const pinnedItemsList = pinnedItems.map((item, index) => {
     return (
-      <Grid item key={`pinned-item-${index}`} sm={6} data-cy="information-card">
+      <Grid item key={`pinned-item-${index}`} xs={12} sm={6} data-cy="information-card">
         <InformationCard item={item} />
       </Grid>
     );


### PR DESCRIPTION
pt story: https://www.pivotaltracker.com/story/show/179763106

sets a pixel height for info snippet cards and items to be certain height regardless of content 

## Screenshot 
![newInfoSnippet](https://user-images.githubusercontent.com/63557569/135433751-249b8ea9-705c-4ec8-aa1a-18678085269e.png)


