### PR TITLE
White navbar on info, West London PCN boundary

### DIFF
--- a/src/components/Navbar/ApplicationHeader.jsx
+++ b/src/components/Navbar/ApplicationHeader.jsx
@@ -54,11 +54,19 @@ const ApplicationHeader = () => {
       setActiveSecondaryTab,
       setParent
     );
-  }, [appDataFetched, main_tabs, currentUrl, setActiveMainTab, setActiveSecondaryTab]);
+  }, [
+    appDataFetched,
+    main_tabs,
+    currentUrl,
+    setActiveMainTab,
+    setActiveSecondaryTab,
+  ]);
 
   const handleChangeSecondary = (event, newValue) => {
     setActiveSecondaryTab(newValue);
   };
+
+  const isWhite = document.URL.indexOf("news_info/information") >= 0;
 
   const mainTabs = main_tabs.map((tab, index) => (
     <Tab
@@ -67,7 +75,7 @@ const ApplicationHeader = () => {
       data-cy={`${Functions.toKebabCase(tab.label)}-tab`}
       label={tab.label}
       component={Link}
-      to={tab.link}    
+      to={tab.link}
     />
   ));
 
@@ -117,7 +125,12 @@ const ApplicationHeader = () => {
             </Tabs>
           </Toolbar>
           {secondaryTabs.length !== 0 && currentUrl !== "/services/search" && (
-            <Toolbar data-cy="secondary-nav-bar" style={(document.URL.indexOf("news_info/information") >= 0) ? styles.secondaryNavBarInfo : styles.secondaryNavBar}>
+            <Toolbar
+              data-cy="secondary-nav-bar"
+              style={
+                isWhite ? styles.secondaryNavBarInfo : styles.secondaryNavBar
+              }
+            >
               <Tabs
                 style={styles.navTabs}
                 value={activeSecondaryTab}

--- a/src/components/Navbar/ApplicationHeader.jsx
+++ b/src/components/Navbar/ApplicationHeader.jsx
@@ -117,7 +117,7 @@ const ApplicationHeader = () => {
             </Tabs>
           </Toolbar>
           {secondaryTabs.length !== 0 && currentUrl !== "/services/search" && (
-            <Toolbar data-cy="secondary-nav-bar" style={styles.secondaryNavBar}>
+            <Toolbar data-cy="secondary-nav-bar" style={(document.URL.indexOf("news_info/information") >= 0) ? styles.secondaryNavBarInfo : styles.secondaryNavBar}>
               <Tabs
                 style={styles.navTabs}
                 value={activeSecondaryTab}
@@ -153,6 +153,13 @@ const styles = {
     backgroundColor: "#eee",
     borderTop: "1px solid #ccc",
     borderBottom: "1px solid #ccc",
+    left: "0",
+    width: "100%",
+  },
+  secondaryNavBarInfo: {
+    backgroundColor: "#fff",
+    borderTop: "1px solid #ccc",
+    borderBottom: "none",
     left: "0",
     width: "100%",
   },

--- a/src/components/Service.jsx
+++ b/src/components/Service.jsx
@@ -70,7 +70,7 @@ const ScreenSplit = ({ data }) => {
               }
               label={
                 <Typography color="secondary" variant="body2">
-                  Show PCN boundaries
+                  Show West London PCN boundaries
                 </Typography>
               }
             />


### PR DESCRIPTION
### PT: https://www.pivotaltracker.com/story/show/179832610

### Changes:
- Add a condition to make info secondary nav white
- Add West London to show PCN boundaries 

### Imag
![Screenshot 2021-10-06 at 09 45 35](https://user-images.githubusercontent.com/60035332/136161155-c8cdb48c-b5e3-47a1-91fd-1522dfd4f172.png)
![Screenshot 2021-10-06 at 09 45 46](https://user-images.githubusercontent.com/60035332/136161179-f299e933-10de-4edf-b073-1af4b5248a4b.png)
e
![Screenshot 2021-10-06 at 09 46 09](https://user-images.githubusercontent.com/60035332/136161250-27dc50f7-3167-4721-b8f3-0d5ca3df3dd4.png)
s